### PR TITLE
Add argument to SimulationModel.create_simfunction() for solve_ivp compability

### DIFF
--- a/symbtools/test/test_core.py
+++ b/symbtools/test/test_core.py
@@ -529,6 +529,9 @@ class SymbToolsTest2(unittest.TestCase):
         rhs0_s_ivp = mod.create_simfunction(solver="solve_ivp")
         rhs0_s_ivp_wrong_solver = mod.create_simfunction(solver="odeint")
 
+        # any argument that is not solve_ivp or odeint should raise an exception
+        self.assertRaises(ValueError, mod.create_simfunction, solver="unsolve_ode")
+
         res0_1 = rhs0(x0, 0)
         dres0_1 = st.to_np(fxu.subs(lzip(xx, x0) + st.zip0(uu))).squeeze()
 


### PR DESCRIPTION
Added an optional argument that lets the user request a simulation function with the correct argument order to work with solve_ivp (time and state are backwards compared to odeint). Should the user not provide the optional argument, a function for odeint is produced, maintaining backwards compatibility. Tests were written but should maybe moved to different or new test functions. This pull request was discussed during a work related meeting.